### PR TITLE
Bugfix 

### DIFF
--- a/site/templates/index.html.tpl
+++ b/site/templates/index.html.tpl
@@ -275,6 +275,7 @@
             map.parent.style.width = parseInt(map.dimensions.x) + 'px';
             map.parent.style.height = parseInt(map.dimensions.y) + 'px';
             map.draw();
+            onMapChanged(map);
         }
         
         function setLayout(layout)


### PR DESCRIPTION
Changing the papersize has an effect on the  coordinates of the printed map.
If the last action before creating the print is the change of papersize the coordinates are not set to the correct values.
This leads to a gap between walkingpapers an data layer.
So it is  needed to call the onMapChanged(map) callback after change of papersize.
